### PR TITLE
feat: Enhance Google Analytics integration for multi-country support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Extract version and changelog from NEWS.md
         id: changelog
         run: |
-          version=$(grep -m1 -oP '^# peskas\.zanzibar\.v2 \K[0-9]+\.[0-9]+\.[0-9]+' NEWS.md)
+          version=$(grep -m1 -oP '^# peskas\.dashboard \K[0-9]+\.[0-9]+\.[0-9]+' NEWS.md)
           echo "Extracted version: $version"
 
           # Extract changelog from first version block
           changelog=$(awk '
             BEGIN { print_mode=0 }
-            /^# peskas\.zanzibar\.v2 / {
+            /^# peskas\.dashboard / {
               if (print_mode == 1) exit
               if (print_mode == 0) { print_mode=1; next }
             }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,43 @@
+# peskas.dashboard 1.3.1
+
+## Analytics
+
+- **Per-country Google Analytics**: The GA4 measurement ID is now read from
+  `NEXT_PUBLIC_GA_MEASUREMENT_ID` per deployment instead of being hardcoded, so each
+  country domain reports into its own GA4 property. An optional `NEXT_PUBLIC_GA_ROLLUP_ID`,
+  set to the same value on every deployment, mirrors events into a shared property for a
+  platform-wide view. Both are declared in `turbo.json` — without that, Turborepo could
+  reuse one country's cached build for another and ship the wrong measurement ID.
+
+- **Country dimension on every event**: `peskas_country` and `peskas_country_code` are
+  attached globally via `gtag('set')` before `gtag('config')`, so even a shared property can
+  be broken down by country. Both must be registered as event-scoped custom dimensions in
+  GA4, which does not backfill them.
+
+- **Fixed double-counted page views**: The analytics component re-fired `gtag('config')` on
+  every route change while GA4 enhanced measurement was already tracking History API
+  navigations, counting each client-side navigation twice. Page views are now left to
+  enhanced measurement alone. Historical page-view figures are inflated.
+
+- **Analytics component is now a Server Component**: Dropping the `usePathname()` /
+  `useSearchParams()` hooks also removed an unrelated problem — `useSearchParams()` in the
+  root layout with no `<Suspense>` boundary opted statically generated pages into
+  client-side rendering.
+
+- **Custom event tracking**: Five events cover the filter and map controls:
+  `filter_time_range_change`, `filter_metric_change`, `filter_district_change`,
+  `map_basemap_change`, and `map_effort_range_toggle`. They fire through a typed
+  `trackEvent()` helper in `src/lib/analytics.ts` that no-ops when no measurement ID is set.
+  Events are suppressed when a control is re-set to its current value, and nothing fires on
+  mount, hydration, or route-driven state resets.
+
+- **Analytics documentation**: New `apps/isomorphic-i18n/ANALYTICS.md` covers the GA4
+  account structure options, required admin setup, the event and parameter reference, and
+  verification steps. `COUNTRY_SETUP.md` now includes the analytics step when adding a
+  country.
+
+---
+
 # peskas.dashboard 1.3.0
 
 ## Infrastructure

--- a/apps/isomorphic-i18n/ANALYTICS.md
+++ b/apps/isomorphic-i18n/ANALYTICS.md
@@ -1,0 +1,178 @@
+# Analytics — Google Analytics 4
+
+Each country is a separate Vercel project serving its own domain, so each one reports
+into its own GA4 data stream. Nothing in the code inspects the hostname; the split is
+driven entirely by per-deployment environment variables.
+
+---
+
+## How it works
+
+`src/app/_components/google-analytics.tsx` is a Server Component mounted once in
+`src/app/[lang]/layout.tsx`. It renders the `gtag.js` snippet and nothing else.
+
+| Concern | Behaviour |
+|---|---|
+| Which property receives data | `NEXT_PUBLIC_GA_MEASUREMENT_ID`, set per Vercel project |
+| Platform-wide roll-up | `NEXT_PUBLIC_GA_ROLLUP_ID`, optional, same value on every project |
+| Country label on every event | `peskas_country` / `peskas_country_code`, read from `countryConfig.ts` |
+| Page views on client-side navigation | Handled by GA4 enhanced measurement, not by app code |
+| Local dev and preview deploys | Silent — the component returns `null` when no measurement ID is set |
+
+### Why there is no `useEffect` page-view tracking
+
+GA4 enhanced measurement already fires `page_view` on History API changes, which is how
+the App Router navigates. Sending our own `page_view` (or re-calling `gtag('config')`) on
+route change **double-counts every navigation**. This is the single most common GA4 bug in
+Next.js App Router apps, and it is why this component has no hooks and no client bundle.
+
+The trade-off: `page_title` is captured by GA4 at navigation time, which can occasionally
+lag React's title update by a few hundred milliseconds. Use `page_location` / page path as
+the reliable dimension in reports.
+
+---
+
+## Choosing the GA4 account structure
+
+The application code is identical either way — one measurement ID per deployment. Pick
+based on **who needs access to which numbers**.
+
+### Option A — one property per country (recommended when partners get access)
+
+Three GA4 properties, e.g. `Peskas Zanzibar`, `Peskas Kenya`, `Peskas Mozambique`.
+
+- Fully siloed reports; no cross-contamination of totals, audiences, or conversions.
+- Access control per country: a national fisheries partner can be granted their property
+  without seeing the others.
+- No built-in combined view — add the shared `NEXT_PUBLIC_GA_ROLLUP_ID` roll-up property
+  (below) if you also want platform-wide numbers.
+
+### Option B — one property, one web data stream per country
+
+A single `Peskas` property with three streams, one per domain.
+
+- Platform-wide reporting for free; break down by the built-in `Stream name` or `Hostname`
+  dimension, or by `peskas_country`.
+- Simpler admin: one set of custom dimensions, retention settings, and audiences.
+- Standard reports **blend all three countries by default**, so every country-specific
+  report needs a filter or comparison applied.
+- Access is all-or-nothing: anyone with property access sees every country.
+
+### The roll-up property
+
+Setting `NEXT_PUBLIC_GA_ROLLUP_ID` to the same value on all three Vercel projects makes
+`gtag` mirror every event into a second property, giving Option A a combined view as well.
+Break it down by `peskas_country`. Leave the variable empty to disable.
+
+> The pre-existing measurement ID `G-R8LTN94QRZ` was hardcoded and shared by all countries,
+> so its historical data is already blended. It is the natural candidate for the roll-up
+> property if you adopt Option A.
+
+---
+
+## Per-deployment environment variables
+
+Set these in each Vercel project, **Production environment only** so that preview
+deployments do not pollute the reports.
+
+| Variable | Zanzibar | Kenya | Mozambique |
+|---|---|---|---|
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | that country's stream | that country's stream | that country's stream |
+| `NEXT_PUBLIC_GA_ROLLUP_ID` | same on all three, or unset | same | same |
+
+`NEXT_PUBLIC_*` variables are inlined at build time, so **changing either value requires a
+redeploy**, not just an env update. Both are declared in the root `turbo.json` `env` list;
+omitting them there would let Turborepo reuse one country's cached build for another.
+
+---
+
+## Required GA4 admin setup
+
+Per data stream:
+
+1. **Admin → Data streams → your stream → Enhanced measurement**: toggle on, and confirm
+   **"Page changes based on browser history events"** is checked. Client-side navigation is
+   not tracked without this.
+2. **Admin → Data streams → Configure tag settings → Define internal traffic**: add a rule
+   matching `*.vercel.app` so any preview traffic is classified as internal, then exclude
+   internal traffic in the data filter.
+
+Per property (including the roll-up — custom definitions are not shared between
+properties):
+
+3. **Admin → Custom definitions → Create custom dimension**, scope **Event**, for each
+   parameter you want to report on: `peskas_country`, `peskas_country_code`, and the event
+   parameters listed in the next section. GA4 only surfaces a custom parameter in reports
+   once it is registered, and it does **not** backfill, so do this before you need the data.
+
+Note the built-in `Country` dimension is geographic (derived from IP) and is not the same
+thing as `peskas_country`, which identifies the deployment. A user in Nairobi visiting the
+Zanzibar dashboard has `Country = Kenya` and `peskas_country = Zanzibar`.
+
+---
+
+## Custom events
+
+Fired through `trackEvent()` in `src/lib/analytics.ts`, which no-ops when the tag is not
+loaded. Add new event names to the `AnalyticsEvent` union there so typos fail the build.
+
+| Event | Parameters | Fired when |
+|---|---|---|
+| `filter_time_range_change` | `time_range` (`"3"`, `"6"`, `"12"`, `"72"`, `"all"`) | Header time range option picked |
+| `filter_metric_change` | `metric`, `source` (`header` \| `district_widget`) | Metric picked in either control |
+| `filter_district_change` | `action`, `district`, `region`, `district_count` | District selection changed |
+| `map_basemap_change` | `basemap` (`satellite` \| `map`) | Basemap toggled on the grid map |
+| `map_effort_range_toggle` | `effort_range`, `enabled` | Effort band toggled in the map info panel |
+
+`filter_district_change.action` is one of `add`, `remove`, `clear`, `region_add`,
+`region_remove`, or `replace_in_region` (the admin region-view single-select path).
+`district` is absent on region and clear actions; `region` is only present on region actions.
+
+Two deliberate choices in how these fire:
+
+- **No event when nothing changed.** Re-picking the already-selected time range or metric,
+  and deselecting the last remaining effort band (which the map rejects), are all
+  suppressed. Without this the funnel is full of no-op "changes".
+- **Nothing fires on mount, hydration, or navigation.** Only user gestures are tracked. In
+  particular the district list is restored from `localStorage` and the metric is reset by
+  route-driven effects in `MetricSelectorDropdown`; neither is a user action.
+
+Continuous interactions are intentionally not tracked: map pan/zoom
+(`onViewStateChange`), hover tooltips, and the hex-radius slider drag would each produce
+hundreds of events per session and blow through GA4 event quotas.
+
+### Not instrumented: exports
+
+There is no export or download feature in the fisheries dashboard today. The only CSV
+exports in the repo are on template account-settings pages (billing history, logged-in
+devices) that are not part of the Peskas product. When a real export is added, wrap it and
+fire a `data_export` event with the dataset and format; `packages/isomorphic-core/src/utils/export-to-csv.ts`
+is the shared helper it will likely use.
+
+---
+
+## Verifying a deployment
+
+1. Open the production domain and navigate between a few dashboard pages.
+2. GA4 → **Reports → Realtime**: confirm the visit appears in the expected property.
+3. Confirm the navigation count matches the number of pages you visited. Double the
+   expected number means a second GA snippet is present, or manual page-view tracking was
+   reintroduced alongside enhanced measurement.
+4. GA4 → **Admin → DebugView** (with the GA Debugger extension) to inspect that
+   `peskas_country` is attached to events.
+
+To check event wiring without a GA property, run the app with any placeholder measurement
+ID and read the queue in the browser console — `trackEvent` pushes through gtag, so
+`window.dataLayer.filter((e) => e[0] === 'event')` shows exactly what would be sent.
+
+---
+
+## Not implemented
+
+- **Cookie consent / Consent Mode v2.** The tag currently loads unconditionally. Users are
+  primarily in TZ/KE/MZ, but EU-based funders and researchers do visit these dashboards. If
+  consent is required, add `gtag('consent', 'default', ...)` as the first line of the init
+  script in `google-analytics.tsx` — it must run before `gtag('config')` to take effect.
+- **Cross-domain tracking.** Deliberately absent: the country dashboards are separate sites
+  and a user is never expected to travel between them in one session. Enabling the domain
+  linker would merge their sessions.

--- a/apps/isomorphic-i18n/COUNTRY_SETUP.md
+++ b/apps/isomorphic-i18n/COUNTRY_SETUP.md
@@ -128,10 +128,15 @@ Strings to check: `metric-mean_rpue-unit`, `metric-mean_price_kg-unit` (currency
 ```
 NEXT_PUBLIC_COUNTRY_CODE=KE
 MONGODB_URI=<your-kenya-cluster-connection-string>
+NEXT_PUBLIC_GA_MEASUREMENT_ID=<the-new-country-GA4-stream>
 ```
 
 `NEXT_PUBLIC_COUNTRY_CODE` is inlined into the client bundle at build time (Next.js `NEXT_PUBLIC_*`
 convention). A redeploy is required when changing it.
+
+Each country reports into its own GA4 data stream, so the new deployment needs its own
+`NEXT_PUBLIC_GA_MEASUREMENT_ID` plus a registered `peskas_country` custom dimension.
+See [ANALYTICS.md](./ANALYTICS.md) for the GA4 admin steps.
 
 ---
 
@@ -144,4 +149,5 @@ convention). A redeploy is required when changing it.
 - [ ] `regionBreakdown.regions` values match the region names used in `districtToRegion`
 - [ ] Locale files added for each language
 - [ ] `NEXT_PUBLIC_COUNTRY_CODE` and `MONGODB_URI` set in the deployment environment
+- [ ] GA4 stream created and `NEXT_PUBLIC_GA_MEASUREMENT_ID` set on Production (see ANALYTICS.md)
 - [ ] `npx tsc --noEmit` passes in both `apps/isomorphic-i18n/` and `packages/api/`

--- a/apps/isomorphic-i18n/src/app/_components/google-analytics.tsx
+++ b/apps/isomorphic-i18n/src/app/_components/google-analytics.tsx
@@ -1,56 +1,59 @@
-'use client';
-
-import { useEffect } from 'react';
 import Script from 'next/script';
-import { usePathname, useSearchParams } from 'next/navigation';
 
-const GTAG_ID = 'G-R8LTN94QRZ';
+import { activeCountry } from '@/config/countryConfig';
+
+/**
+ * Google Analytics 4 (gtag.js).
+ *
+ * Each country deploys as its own Vercel project, so NEXT_PUBLIC_GA_MEASUREMENT_ID
+ * is set per deployment and points at that country's GA4 data stream. Leaving it
+ * unset (local dev, preview deployments) renders nothing, which keeps non-production
+ * traffic out of the reporting property.
+ *
+ * NEXT_PUBLIC_GA_ROLLUP_ID is optional and shared by every deployment: when set,
+ * gtag mirrors every event to that second property to give a platform-wide view
+ * across all countries. See ANALYTICS.md for the GA4 admin setup.
+ */
+const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const rollupMeasurementId = process.env.NEXT_PUBLIC_GA_ROLLUP_ID;
 
 export default function GoogleAnalytics() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  if (!measurementId) return null;
 
-  // Track page views when the route changes
-  useEffect(() => {
-    if (pathname && window.gtag) {
-      window.gtag('config', GTAG_ID, {
-        page_path: pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : ''),
-      });
-    }
-  }, [pathname, searchParams]);
+  const destinations = rollupMeasurementId
+    ? [measurementId, rollupMeasurementId]
+    : [measurementId];
+
+  // Attached to every event so a single property can be broken down by country.
+  // Register both as event-scoped custom dimensions in GA4 to use them in reports.
+  const globalParams = {
+    peskas_country: activeCountry.countryName,
+    peskas_country_code: activeCountry.countryCode,
+  };
+
+  // gtag('set') must precede gtag('config') so the automatic first page_view
+  // carries the country params. No page_view is sent on route change here:
+  // GA4 enhanced measurement tracks App Router navigations via History API
+  // events, and firing our own would double-count every navigation.
+  const initScript = [
+    'window.dataLayer = window.dataLayer || [];',
+    'function gtag(){dataLayer.push(arguments);}',
+    "gtag('js', new Date());",
+    `gtag('set', ${JSON.stringify(globalParams)});`,
+    ...destinations.map((id) => `gtag('config', ${JSON.stringify(id)});`),
+  ].join('\n');
 
   return (
     <>
-      {/* Global Site Tag (gtag.js) - Google Analytics */}
       <Script
         strategy="afterInteractive"
-        src={`https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
       />
-      <Script 
-        id="gtag-init" 
+      <Script
+        id="gtag-init"
         strategy="afterInteractive"
-        dangerouslySetInnerHTML={{
-          __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GTAG_ID}', {
-              page_path: window.location.pathname,
-            });
-          `,
-        }}
+        dangerouslySetInnerHTML={{ __html: initScript }}
       />
     </>
   );
 }
-
-// Add TypeScript declaration for gtag
-declare global {
-  interface Window {
-    gtag: (
-      command: string,
-      targetId: string,
-      config?: Record<string, any>
-    ) => void;
-  }
-} 

--- a/apps/isomorphic-i18n/src/app/components/filter-selector.tsx
+++ b/apps/isomorphic-i18n/src/app/components/filter-selector.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "@/app/i18n/client";
 import cn from "@utils/class-names";
 import { api } from "@/trpc/react";
 import { activeCountry } from "@/config/countryConfig";
+import { trackEvent } from "@/lib/analytics";
 
 type DropdownTypes = {
   sectionName: string;
@@ -165,7 +166,13 @@ export const FilterSelector = () => {
             {selectedCount > 0 && (
               <button
                 className="text-primary hover:text-primary-dark"
-                onClick={() => setSelectedDistricts([])}
+                onClick={() => {
+                  trackEvent("filter_district_change", {
+                    action: "clear",
+                    district_count: 0,
+                  });
+                  setSelectedDistricts([]);
+                }}
               >
                 Clear all
               </button>
@@ -215,14 +222,25 @@ const FilterGroup = ({
       const filteredDistricts = districts.filter(
         district => !section.units.some(u => u.value === district)
       );
-      setDistricts([...filteredDistricts, unit]);
+      const next = [...filteredDistricts, unit];
+      trackEvent("filter_district_change", {
+        action: "replace_in_region",
+        district: unit,
+        district_count: next.length,
+      });
+      setDistricts(next);
       return;
     }
-    if (districts.includes(unit)) {
-      setDistricts(districts.filter((d) => d !== unit));
-    } else {
-      setDistricts([...districts, unit]);
-    }
+    const isRemoving = districts.includes(unit);
+    const next = isRemoving
+      ? districts.filter((d) => d !== unit)
+      : [...districts, unit];
+    trackEvent("filter_district_change", {
+      action: isRemoving ? "remove" : "add",
+      district: unit,
+      district_count: next.length,
+    });
+    setDistricts(next);
   };
 
   if (typeof districtSection === "string" && searchFilter) {
@@ -245,19 +263,34 @@ const FilterGroup = ({
       : section.units.every(unit => districts.includes(unit.value));
 
     const handleSectionSelect = () => {
+      const trackRegion = (next: string[]) =>
+        trackEvent("filter_district_change", {
+          action: isRegionSelected ? "region_remove" : "region_add",
+          region: section.sectionName,
+          district_count: next.length,
+        });
+
       if (isAdmin && viewMode === 'region') {
         if (isRegionSelected) {
-          setDistricts(districts.filter(d => !section.units.some(u => u.value === d)));
+          const next = districts.filter(d => !section.units.some(u => u.value === d));
+          trackRegion(next);
+          setDistricts(next);
         } else {
           const filtered = districts.filter(d => !section.units.some(u => u.value === d));
-          setDistricts([...filtered, section.units[0].value]);
+          const next = [...filtered, section.units[0].value];
+          trackRegion(next);
+          setDistricts(next);
         }
         return;
       }
       if (isRegionSelected) {
-        setDistricts(districts.filter(d => !section.units.map(u => u.value).includes(d)));
+        const next = districts.filter(d => !section.units.map(u => u.value).includes(d));
+        trackRegion(next);
+        setDistricts(next);
       } else {
-        setDistricts([...districts, ...section.units.map(u => u.value)]);
+        const next = [...districts, ...section.units.map(u => u.value)];
+        trackRegion(next);
+        setDistricts(next);
       }
     };
 

--- a/apps/isomorphic-i18n/src/app/components/time-range-selector.tsx
+++ b/apps/isomorphic-i18n/src/app/components/time-range-selector.tsx
@@ -6,6 +6,7 @@ import { PiCaretDownBold, PiClockCountdownDuotone } from "react-icons/pi";
 import { Popover } from "rizzui";
 import cn from "@utils/class-names";
 import { useTranslation } from "@/app/i18n/client";
+import { trackEvent } from "@/lib/analytics";
 
 // Global time range selector atom and options
 export const TIME_RANGES = [
@@ -29,6 +30,15 @@ export default function TimeRangeSelector() {
     { label: t("text-last-year") || "Last year", value: 12 },
     { label: t("text-all-time") || "All time", value: "all" },
   ];
+
+  const handleSelect = (value: string | number) => {
+    // Re-picking the current range is not a filter change.
+    if (value !== selectedTimeRange) {
+      trackEvent("filter_time_range_change", { time_range: String(value) });
+    }
+    setSelectedTimeRange(value);
+    setIsOpen(false);
+  };
 
   return (
     <Popover isOpen={isOpen} setIsOpen={setIsOpen} placement="bottom-end">
@@ -55,10 +65,7 @@ export default function TimeRangeSelector() {
         {translatedTimeRanges.map((option) => (
           <button
             key={option.value}
-            onClick={() => {
-              setSelectedTimeRange(option.value);
-              setIsOpen(false);
-            }}
+            onClick={() => handleSelect(option.value)}
             className={cn(
               "w-full px-2 py-1.5 text-left text-sm rounded transition-colors",
               selectedTimeRange === option.value

--- a/apps/isomorphic-i18n/src/app/shared/components/MetricSelectorDropdown.tsx
+++ b/apps/isomorphic-i18n/src/app/shared/components/MetricSelectorDropdown.tsx
@@ -8,6 +8,7 @@ import { CURRENCY_CODE } from '@/config/constants';
 import { selectedMetricAtom, selectedRevenueMetricAtom } from '@/app/components/filter-selector';
 import { useTranslation } from '@/app/i18n/client';
 import { usePathname } from 'next/navigation';
+import { trackEvent } from '@/lib/analytics';
 
 export default function MetricSelectorDropdown() {
   const { t } = useTranslation('common');
@@ -75,6 +76,16 @@ export default function MetricSelectorDropdown() {
   
   const selectedMetricOption = availableMetrics.find((m) => m.value === currentMetric);
 
+  const handleMetricSelect = (value: MetricKey) => {
+    // Re-picking the current metric is not a filter change. The route-driven resets
+    // in the effects below are deliberately not tracked.
+    if (value !== currentMetric) {
+      trackEvent('filter_metric_change', { metric: value, source: 'header' });
+    }
+    setCurrentMetric(value);
+    setIsMetricOpen(false);
+  };
+
   const getDisplayLabel = (option: any) => {
     switch (option.value) {
       case 'mean_effort': return t('text-metrics-effort');
@@ -137,7 +148,7 @@ export default function MetricSelectorDropdown() {
               {groupedMetrics.catch.map((option) => (
                 <button
                   key={option.value}
-                  onClick={() => { setCurrentMetric(option.value as MetricKey); setIsMetricOpen(false); }}
+                  onClick={() => handleMetricSelect(option.value as MetricKey)}
                   className={cn(
                     'w-full px-2 py-1.5 text-left text-sm rounded transition-colors flex flex-col items-start gap-0.5',
                     currentMetric === option.value
@@ -162,7 +173,7 @@ export default function MetricSelectorDropdown() {
               {groupedMetrics.revenue.map((option) => (
                 <button
                   key={option.value}
-                  onClick={() => { setCurrentMetric(option.value as MetricKey); setIsMetricOpen(false); }}
+                  onClick={() => handleMetricSelect(option.value as MetricKey)}
                   className={cn(
                     'w-full px-2 py-1.5 text-left text-sm rounded transition-colors flex flex-col items-start gap-0.5',
                     currentMetric === option.value

--- a/apps/isomorphic-i18n/src/app/shared/file/dashboard/district-map-and-bar.tsx
+++ b/apps/isomorphic-i18n/src/app/shared/file/dashboard/district-map-and-bar.tsx
@@ -9,10 +9,19 @@ import type { MetricKey } from "@/app/shared/file/dashboard/charts/types";
 import { Select, SelectItem, SelectTrigger, SelectValue, SelectContent } from "@ui/select";
 import DistrictSummaryBar, { METRICS } from "./district-summary-bar";
 import GridMap from "./grid-map";
+import { trackEvent } from "@/lib/analytics";
 
 export default function DistrictMapAndBar({ lang = 'en', className }: { lang?: string, className?: string }) {
     const { t } = useTranslation("common");
     const [selectedMetric, setSelectedMetric] = useAtom(selectedMetricAtom);
+
+    // Same atom as the header dropdown, tagged by source to show which control is used.
+    const handleMetricChange = (value: MetricKey) => {
+        if (value !== selectedMetric) {
+            trackEvent('filter_metric_change', { metric: value, source: 'district_widget' });
+        }
+        setSelectedMetric(value);
+    };
 
     return (
         <WidgetCard
@@ -22,7 +31,7 @@ export default function DistrictMapAndBar({ lang = 'en', className }: { lang?: s
                         {t("text-district-summary")}
                     </span>
                     <div className="min-w-fit">
-                        <Select value={selectedMetric} onValueChange={(v) => setSelectedMetric(v as MetricKey)}>
+                        <Select value={selectedMetric} onValueChange={(v) => handleMetricChange(v as MetricKey)}>
                             <SelectTrigger className="w-full max-w-[180px] sm:max-w-[240px] md:max-w-[300px]">
                                 <SelectValue>{t(METRICS.find(m => m.key === selectedMetric)?.labelKey || "")}</SelectValue>
                             </SelectTrigger>

--- a/apps/isomorphic-i18n/src/app/shared/file/dashboard/grid-map/index.tsx
+++ b/apps/isomorphic-i18n/src/app/shared/file/dashboard/grid-map/index.tsx
@@ -29,6 +29,7 @@ import {
   getColorForValue,
 } from './colors';
 import { InfoPanel } from './info-panel';
+import { trackEvent } from '@/lib/analytics';
 
 const GridMap = memo(function GridMap({ lang = 'en' }: GridMapProps) {
   const { theme: rawTheme = 'light' } = useTheme();
@@ -110,6 +111,16 @@ const GridMap = memo(function GridMap({ lang = 'en' }: GridMapProps) {
   );
 
   const handleRangeToggle = useCallback((range: TimeBreak) => {
+    const wasSelected = selectedRanges.some(
+      (r) => r.min === range.min && r.max === range.max
+    );
+    // Deselecting the last remaining range is rejected below, so it is not a change.
+    if (!wasSelected || selectedRanges.length > 1) {
+      trackEvent('map_effort_range_toggle', {
+        effort_range: range.label,
+        enabled: !wasSelected,
+      });
+    }
     setSelectedRanges((current: TimeBreak[]) => {
       const isSelected = current.some(
         (r) => r.min === range.min && r.max === range.max
@@ -121,7 +132,7 @@ const GridMap = memo(function GridMap({ lang = 'en' }: GridMapProps) {
       }
       return [...current, range];
     });
-  }, []);
+  }, [selectedRanges]);
 
   const getTooltip = useCallback(
     (info: {
@@ -277,7 +288,11 @@ const GridMap = memo(function GridMap({ lang = 'en' }: GridMapProps) {
       {/* Single Icon Map Style Switcher, now theme-aware */}
       <div style={{ position: 'absolute', top: 16, right: 16, zIndex: 10 }}>
         <button
-          onClick={() => setViewMode(viewMode === 'satellite' ? 'map' : 'satellite')}
+          onClick={() => {
+            const next = viewMode === 'satellite' ? 'map' : 'satellite';
+            trackEvent('map_basemap_change', { basemap: next });
+            setViewMode(next);
+          }}
           style={{
             background: theme === 'dark' ? 'rgba(30,41,59,0.85)' : 'rgba(255,255,255,0.85)',
             border: theme === 'dark' ? '1px solid #334155' : '1px solid #d1d5db',

--- a/apps/isomorphic-i18n/src/lib/analytics.ts
+++ b/apps/isomorphic-i18n/src/lib/analytics.ts
@@ -1,0 +1,38 @@
+'use client';
+
+/**
+ * Client-side wrapper for GA4 custom events.
+ *
+ * No-ops when gtag is absent, which is the case in local development and on preview
+ * deployments: google-analytics.tsx only renders the tag when
+ * NEXT_PUBLIC_GA_MEASUREMENT_ID is set. Callers never pass the country — the init
+ * snippet attaches peskas_country to every event globally.
+ *
+ * Each event parameter must be registered as a custom dimension in GA4 before it
+ * shows up in reports, and GA4 does not backfill. See ANALYTICS.md.
+ */
+
+/** GA4 event names must be snake_case and 40 characters or fewer. */
+export type AnalyticsEvent =
+  | 'filter_time_range_change'
+  | 'filter_metric_change'
+  | 'filter_district_change'
+  | 'map_basemap_change'
+  | 'map_effort_range_toggle';
+
+type AnalyticsParams = Record<string, string | number | boolean>;
+
+declare global {
+  interface Window {
+    gtag?: (
+      command: 'event',
+      eventName: string,
+      params?: AnalyticsParams
+    ) => void;
+  }
+}
+
+export function trackEvent(event: AnalyticsEvent, params?: AnalyticsParams) {
+  if (typeof window === 'undefined') return;
+  window.gtag?.('event', event, params);
+}

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,8 @@
         "VERCEL_URL",
         "VERCEL",
         "NEXT_PUBLIC_COUNTRY_CODE",
+        "NEXT_PUBLIC_GA_MEASUREMENT_ID",
+        "NEXT_PUBLIC_GA_ROLLUP_ID",
         "VITE_MAPBOX_TOKEN"
       ]
     },
@@ -37,6 +39,8 @@
     "VERCEL_URL",
     "VERCEL",
     "NEXT_PUBLIC_COUNTRY_CODE",
+    "NEXT_PUBLIC_GA_MEASUREMENT_ID",
+    "NEXT_PUBLIC_GA_ROLLUP_ID",
     "VITE_MAPBOX_TOKEN"
   ]
 }


### PR DESCRIPTION
- Updated the analytics setup to read the GA4 measurement ID from environment variables, allowing each country to report to its own GA4 property.
- Implemented global country dimensions for events to enable breakdowns by country in shared properties.
- Fixed double-counting of page views by relying on GA4's enhanced measurement for client-side navigation.
- Converted the analytics component to a Server Component, improving performance and resolving rendering issues.
- Added custom event tracking for filter and map controls, with a new `trackEvent()` helper for streamlined event management.
- Created comprehensive analytics documentation detailing setup and event tracking requirements for new deployments.